### PR TITLE
Support Tariff Lookup Tool inputs

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,36 +1,35 @@
-from flask import Flask, request, jsonify
+from flask import Flask, request, jsonify, render_template
 import xlwings as xw
 
-app = Flask(__name__)  # ✅ 定義 app 變數
+app = Flask(__name__)
+
 
 @app.route('/')
 def index():
-    return '''
-        <form method="post" action="/calculate">
-            A: <input name="param1"><br>
-            B: <input name="param2"><br>
-            <button type="submit">Calculate</button>
-        </form>
-    '''
+    return render_template('index.html')
+
 
 @app.route('/calculate', methods=['POST'])
 def calculate():
-    a = float(request.form['param1'])
-    b = float(request.form['param2'])
+    product_coo = request.form.get('product_coo', '')
+    hts_code = request.form.get('hts_code', '')
 
-    wb = xw.Book('workbook.xlsx')  # 確保同資料夾中有這個檔案
-    sht = wb.sheets[0]
+    wb = xw.Book('Tariff Lookup Tool.xlsx')
+    sht = wb.sheets['Enter Importer Data Here']
 
-    sht.range('A1').value = a
-    sht.range('B1').value = b
+    sht.range('C2').value = product_coo
+    sht.range('D2').value = hts_code
 
-    wb.app.calculate()  # 讓 Excel 運算公式
+    wb.app.calculate()
 
-    result = sht.range('C1').value
+    cells = ['M2', 'Q2', 'T2', 'AV2', 'AE2', 'AF2']
+    results = {cell: sht.range(cell).value for cell in cells}
 
     wb.save()
     wb.close()
 
-    return jsonify({'result': result})
-if __name__ == "__main__":
+    return jsonify(results)
+
+
+if __name__ == '__main__':
     app.run(debug=True)

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,29 +1,34 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>Excel Calculator</title>
+    <title>Tariff Lookup Tool</title>
 </head>
 <body>
-    <h2>Excel 後端加總計算</h2>
+    <h2>Tariff Lookup Tool</h2>
     <form id="calcForm">
-        參數 A: <input type="text" name="param1"><br>
-        參數 B: <input type="text" name="param2"><br>
-        <button type="submit">計算</button>
+        Product COO: <input type="text" name="product_coo"><br>
+        HTS Code: <input type="text" name="hts_code"><br>
+        <button type="submit">Submit</button>
     </form>
-    <p id="result"></p>
+    <div id="results"></div>
 
     <script>
         document.getElementById('calcForm').addEventListener('submit', function(e) {
             e.preventDefault();
             const formData = new FormData(this);
-
             fetch('/calculate', {
                 method: 'POST',
                 body: formData
             })
             .then(res => res.json())
             .then(data => {
-                document.getElementById('result').innerText = '計算結果為：' + data.result;
+                document.getElementById('results').innerHTML =
+                    'M2: ' + data.M2 + '<br>' +
+                    'Q2: ' + data.Q2 + '<br>' +
+                    'T2: ' + data.T2 + '<br>' +
+                    'AV2: ' + data.AV2 + '<br>' +
+                    'AE2: ' + data.AE2 + '<br>' +
+                    'AF2: ' + data.AF2;
             });
         });
     </script>


### PR DESCRIPTION
## Summary
- overhaul Flask app to read from **Tariff Lookup Tool.xlsx** instead of the toy workbook
- allow users to input Product COO and HTS Code on the main page
- save values to the Excel sheet `Enter Importer Data Here` and return several cells

## Testing
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6864a84efc70832092c01af27e76c316