### PR TITLE
Align result percentages and widen table

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -29,9 +29,21 @@
             width: 100%;
             max-width: 600px;
         }
+        #results-table {
+            max-width: 1100px;
+        }
         th, td {
             border: 1px solid #ccc;
             padding: 8px 12px;
+        }
+        #results-table td:nth-child(n+3) {
+            text-align: right;
+        }
+        #results-table th:nth-child(7) {
+            width: 180px;
+        }
+        #results-table th:nth-child(8) {
+            width: 300px;
         }
         th {
             background-color: #1976D2;


### PR DESCRIPTION
## Summary
- adjust results table width
- right-align percentage results
- set wider column widths for long headers

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6864d6346f00832092f31a22c22a49b6